### PR TITLE
Réparation constructeur

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -101,15 +101,15 @@ class Config extends AbstractConfig implements ConfigurationInterface
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Framework\App\State $appState,
         \Psr\Log\LoggerInterface $logger,
-        \Magento\Framework\App\Config\Storage\WriterInterface $configWriter,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Magento\Framework\App\Cache\Frontend\Pool $cacheFrontendPool,
         $params = []
     ) {
-        parent::__construct($scopeConfig, $configWriter, $cacheTypeList, $cacheFrontendPool);
+        parent::__construct($scopeConfig, $configWriter);
         $this->_storeManager = $storeManager;
         $this->appState = $appState;
         $this->logger = $logger;


### PR DESCRIPTION
L'ordre des paramètres déclarés est incorrect, mais plus bloquant encore, vous passez les paramètres "$cacheTypeList" et "$cacheFrontendPool" à l'appel du constructeur parent, qui lui ne les a pas.

De ce fait, la compilation des di en mode production ne fonctionne pas.