### PR TITLE
Fix inifinite JS loop on checkout failure

### DIFF
--- a/view/frontend/web/js/view/cart/refreshCart.js
+++ b/view/frontend/web/js/view/cart/refreshCart.js
@@ -1,10 +1,16 @@
-require(['jquery', 'Magento_Customer/js/customer-data'], function (
-  $,
-  customerData
-) {
-  $(document).on('ajaxComplete', function () {
-    var sections = ['cart'];
-    customerData.invalidate(sections);
-    customerData.reload(sections, true);
-  });
+require([
+    'jquery',
+    'Magento_Customer/js/customer-data'
+], function ($, customerData) {
+    var isReloaded = false;
+
+    $(document).on('ajaxComplete', function(){
+        if (!isReloaded) {
+            var sections = ['cart'];
+            customerData.invalidate(sections);
+            customerData.reload(sections, true);
+
+            isReloaded = true;
+        }
+    });
 });


### PR DESCRIPTION
### Pré-conditions

1. Module HiPay installé (`hipay/hipay-fullservice-sdk-magento2`) dans sa dernière version (1.13.3 à date)

### Étapes pour reproduire

1. Créer un produit à 13,04€ pour simuler un paiement refusé
2. Payer avec la carte de test 4111111111111111
3. Atterrir sur la page d'échec de paiement (`checkout/onepage/failure`)
4. Quitter la page d'échec de paiement pour revenir par exemple sur la homepage
5. Ouvrir le mini-panier

### Résultat attendu

1. Le mini-panier est bien affiché et contient bien le produit rajouté au panier par le Controller `\HiPay\FullserviceMagento\Controller\Redirect\Decline`

### Résultat actuel

1. Le compteur de produits du mini-panier est ok mais ce-dernier apparaît vide

### Informations relatives au fix

L'event écouté pour déclencher le rechargement de la section `cart` par le JS est `ajaxComplete`, sauf que le rechargement des sections se fait lui-même en AJAX, ce qui cause une boucle infinie de rechargement du panier.

De ce fait on peut constater dans la console du navigateur (onglet "Network") des appels infinis au rechargement du panier.

Cela a plusieurs effets négatifs :

- Consommation des ressources du navigateur du client
- Mini-panier rechargeant en boucle (donc effet de "clignottement" du contenu) si ouvert sur la page `checkout/onepage/failure`
- Erreur JavaScript à la première ouverture du mini-panier en dehors de cette page d'échec de paiement le rendant complètement vide

Je pense que l'utilisation de l'event `ajaxComplete` est inutile mais ne voulant pas trop affecter votre code, j'ai opté pour la solution la plus simple qui était d'ajouter une variable de type booléen pour détecter un rechargement déjà effectué.