### PR TITLE
Correction on product description retrieval for CommonRequest

### DIFF
--- a/Model/Request/CommonRequest.php
+++ b/Model/Request/CommonRequest.php
@@ -200,7 +200,11 @@ abstract class CommonRequest extends BaseRequest
             switch ($item->getType()) {
                 case TypeItems::GOOD:
                     $product = $this->_productRepositoryInterface->getById($productId);
-                    $description = $product->getCustomAttribute('description');
+                    $descriptionAttribute = $product->getCustomAttribute('description');
+                    $description = $descriptionAttribute !== null
+                        ? $descriptionAttribute->getValue()
+                        : $product->getDescription();
+
                     $itemHipay = new Item();
                     $itemHipay->setName($name);
                     $itemHipay->setProductReference($reference);
@@ -210,7 +214,7 @@ abstract class CommonRequest extends BaseRequest
                     $itemHipay->setTaxRate($taxPercent);
                     $itemHipay->setDiscount($discount);
                     $itemHipay->setTotalAmount($amount);
-                    $itemHipay->setProductDescription($this->escapeHtmlToJson($description->getValue()));
+                    $itemHipay->setProductDescription($this->escapeHtmlToJson($description));
                     $itemHipay->setProductCategory($this->getMappingCategory($product));
 
                     // Set Specifics informations as EAN


### PR DESCRIPTION
Bug observé sur `magento/product-enterprise-edition 2.4.3`: 

Lorsque l'on configure le module Magento 2 pour envoyer les données du panier à HiPay, une erreur survient pour récupérer la description d'un produit : 

```
Error: Call to a member function getValue() on null in vendor/hipay/hipay-fullservice-sdk-magento2/Model/Request/CommonRequest.php:213
```

Cette erreur empêche la création de la commande côté Magento et le client reste bloqué sur le checkout.