### PR TITLE
#170: Fix issue with frontend scope for ResponseNotFoundOrderRepositoryInterface preference 

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -18,6 +18,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="HiPay\FullserviceMagento\Api\ResponseNotFoundOrderRepositoryInterface" type="HiPay\FullserviceMagento\Model\ResponseNotFoundOrderRepository"/>
     <type name="Magento\Sales\Model\Order\Payment\State\CaptureCommand">
         <plugin name="hipay_capture" type="\HiPay\FullserviceMagento\Plugin\CaptureCommandPlugin" sortOrder="100" disabled="false"/>
     </type>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -19,7 +19,6 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="HiPay\FullserviceMagento\Api\Data\NotificationInterface" type="HiPay\FullserviceMagento\Model\Notification"/>
-    <preference for="HiPay\FullserviceMagento\Api\ResponseNotFoundOrderRepositoryInterface" type="HiPay\FullserviceMagento\Model\ResponseNotFoundOrderRepository"/>
     <type name="Magento\Payment\Model\Method\Providers\CcGenericConfigProvider">
         <arguments>
             <argument name="methodCodes" xsi:type="array">


### PR DESCRIPTION
This PR fixes this bug: https://github.com/hipay/hipay-fullservice-sdk-magento2/issues/170